### PR TITLE
Disease pathway names will now be red in the molecules and download tabs

### DIFF
--- a/src/main/java/org/reactome/web/pwp/client/details/tabs/downloads/DownloadsTabDisplay.java
+++ b/src/main/java/org/reactome/web/pwp/client/details/tabs/downloads/DownloadsTabDisplay.java
@@ -18,6 +18,7 @@ import org.reactome.web.pwp.client.details.tabs.downloads.widgets.DownloadItem;
 import org.reactome.web.pwp.client.details.tabs.downloads.widgets.DownloadType;
 import org.reactome.web.pwp.client.details.tabs.downloads.widgets.DownloadURLBuilder;
 import org.reactome.web.pwp.model.client.classes.DatabaseObject;
+import org.reactome.web.pwp.model.client.classes.Event;
 
 import java.util.List;
 
@@ -127,6 +128,10 @@ public class DownloadsTabDisplay extends ResizeComposite implements DownloadsTab
     private Widget getTitle(DatabaseObject databaseObject){
         HorizontalPanel titlePanel = new HorizontalPanel();
         titlePanel.setStyleName("elv-Download-Title");
+        if (((Event) databaseObject).getInDisease()) {
+            titlePanel.addStyleName("elv-Download-Title-Disease");
+        }
+
         try{
             ImageResource img = databaseObject.getImageResource();
             String helpTitle = databaseObject.getSchemaClass().name;

--- a/src/main/java/org/reactome/web/pwp/client/details/tabs/downloads/DownloadsTabDisplay.java
+++ b/src/main/java/org/reactome/web/pwp/client/details/tabs/downloads/DownloadsTabDisplay.java
@@ -128,9 +128,7 @@ public class DownloadsTabDisplay extends ResizeComposite implements DownloadsTab
     private Widget getTitle(DatabaseObject databaseObject){
         HorizontalPanel titlePanel = new HorizontalPanel();
         titlePanel.setStyleName("elv-Download-Title");
-        if (((Event) databaseObject).getInDisease()) {
-            titlePanel.addStyleName("elv-Download-Title-Disease");
-        }
+        if (((Event) databaseObject).getInDisease()) { titlePanel.addStyleName("elv-Download-Title-Disease"); }
 
         try{
             ImageResource img = databaseObject.getImageResource();

--- a/src/main/java/org/reactome/web/pwp/client/details/tabs/molecules/model/MoleculesPanel.java
+++ b/src/main/java/org/reactome/web/pwp/client/details/tabs/molecules/model/MoleculesPanel.java
@@ -119,6 +119,8 @@ public class MoleculesPanel extends DockLayoutPanel implements MouseOverHandler,
     private Widget getTitle(DatabaseObject databaseObject) {
         HorizontalPanel titlePanel = new HorizontalPanel();
         titlePanel.setStyleName("elv-Details-Title");
+        if (((Event) databaseObject).getInDisease()) titlePanel.addStyleName("elv-Details-Title-Disease");
+
         try{
             ImageResource img = databaseObject.getImageResource();
             String helpTitle = databaseObject.getSchemaClass().name;

--- a/src/main/webapp/index.css
+++ b/src/main/webapp/index.css
@@ -416,6 +416,11 @@ body {
     float: left;
 }
 
+.elv-Download-Title.elv-Download-Title-Disease {
+    background-color: #e092b3;
+    color: #BA1149;
+}
+
 .elv-Download-ItemsPanel {
     margin: 5px;
 }


### PR DESCRIPTION
Fix for this [bug](https://trello.com/c/G8VWjuHK/6-browser-details-tab-pathway-name-colour-for-disease)

