### PR TITLE
Fix for when GEE and OtherEntity broken link when click on the icon

### DIFF
--- a/src/main/java/org/reactome/web/pwp/client/common/events/SpeciesListRetrievedEvent.java
+++ b/src/main/java/org/reactome/web/pwp/client/common/events/SpeciesListRetrievedEvent.java
@@ -1,0 +1,31 @@
+package org.reactome.web.pwp.client.common.events;
+
+import com.google.gwt.event.shared.GwtEvent;
+import org.reactome.web.pwp.client.common.handlers.SpeciesListRetrievedHandler;
+import org.reactome.web.pwp.model.client.classes.Species;
+
+import java.util.List;
+
+public class SpeciesListRetrievedEvent extends GwtEvent<SpeciesListRetrievedHandler> {
+    public static Type<SpeciesListRetrievedHandler> TYPE = new Type<>();
+    private List<Species> speciesList;
+
+    public SpeciesListRetrievedEvent(List<Species> speciesList) {
+        this.speciesList = speciesList;
+    }
+
+    @Override
+    public Type<SpeciesListRetrievedHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    @Override
+    protected void dispatch(SpeciesListRetrievedHandler handler) {
+        handler.onSpeciesListRetrieved(this);
+    }
+
+    public List<Species> getSpeciesList() {
+        return speciesList;
+    }
+
+}

--- a/src/main/java/org/reactome/web/pwp/client/common/handlers/SpeciesListRetrievedHandler.java
+++ b/src/main/java/org/reactome/web/pwp/client/common/handlers/SpeciesListRetrievedHandler.java
@@ -1,0 +1,8 @@
+package org.reactome.web.pwp.client.common.handlers;
+
+import com.google.gwt.event.shared.EventHandler;
+import org.reactome.web.pwp.client.common.events.SpeciesListRetrievedEvent;
+
+public interface SpeciesListRetrievedHandler extends EventHandler {
+    void onSpeciesListRetrieved(SpeciesListRetrievedEvent event);
+}

--- a/src/main/java/org/reactome/web/pwp/client/manager/state/State.java
+++ b/src/main/java/org/reactome/web/pwp/client/manager/state/State.java
@@ -30,6 +30,7 @@ public class State {
     }
 
     private Species species;
+    private List<Species> speciesList;
 
     /**
      * event can either be a Pathway or a ReactionLikeEvent (these are linkable as default parameters)
@@ -131,7 +132,12 @@ public class State {
         this.analysisStatus = state.analysisStatus;
         this.flag = state.flag;
         this.flagIncludeInteractors = state.flagIncludeInteractors;
+        this.speciesList = state.speciesList;
     }
+
+    public void setSpeciesList(List<Species> speciesList) { this.speciesList = speciesList;}
+
+    public List<Species> getSpeciesList() { return this.speciesList;}
 
     void doConsistencyCheck(final StateLoadedHandler handler) {
         if (event != null) {

--- a/src/main/java/org/reactome/web/pwp/client/manager/state/State.java
+++ b/src/main/java/org/reactome/web/pwp/client/manager/state/State.java
@@ -30,7 +30,6 @@ public class State {
     }
 
     private Species species;
-    private List<Species> speciesList;
 
     /**
      * event can either be a Pathway or a ReactionLikeEvent (these are linkable as default parameters)
@@ -132,12 +131,7 @@ public class State {
         this.analysisStatus = state.analysisStatus;
         this.flag = state.flag;
         this.flagIncludeInteractors = state.flagIncludeInteractors;
-        this.speciesList = state.speciesList;
     }
-
-    public void setSpeciesList(List<Species> speciesList) { this.speciesList = speciesList;}
-
-    public List<Species> getSpeciesList() { return this.speciesList;}
 
     void doConsistencyCheck(final StateLoadedHandler handler) {
         if (event != null) {

--- a/src/main/java/org/reactome/web/pwp/client/manager/state/StateManager.java
+++ b/src/main/java/org/reactome/web/pwp/client/manager/state/StateManager.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class StateManager implements BrowserModule.Manager, ValueChangeHandler<String>,
         State.StateLoadedHandler, StateChangedHandler, DatabaseObjectSelectedHandler, DetailsTabChangedHandler,
         DiagramObjectsFlagResetHandler, AnalysisCompletedHandler, AnalysisResetHandler, AnalysisFilterChangedHandler,
-        ToolSelectedHandler, TermFlaggedHandler {
+        ToolSelectedHandler, TermFlaggedHandler, SpeciesListRetrievedHandler {
 
     private EventBus eventBus;
 
@@ -53,6 +53,7 @@ public class StateManager implements BrowserModule.Manager, ValueChangeHandler<S
         this.eventBus.addHandler(DiagramObjectsFlagResetEvent.TYPE, this);
         this.eventBus.addHandler(AnalysisFilterChangedEvent.TYPE, this);
         this.eventBus.addHandler(TermFlaggedEvent.TYPE, this);
+        this.eventBus.addHandler(SpeciesListRetrievedEvent.TYPE, this);
     }
 
     @Override
@@ -97,6 +98,12 @@ public class StateManager implements BrowserModule.Manager, ValueChangeHandler<S
     }
 
     @Override
+    public void onSpeciesListRetrieved(SpeciesListRetrievedEvent event) {
+        State state = new State(this.currentState);
+        state.setSpeciesList(event.getSpeciesList());
+    }
+
+    @Override
     public void onDatabaseObjectSelected(DatabaseObjectSelectedEvent event) {
         Selection newSelection = event.getSelection();
         Selection currentSelection = new Selection(currentState);
@@ -128,7 +135,7 @@ public class StateManager implements BrowserModule.Manager, ValueChangeHandler<S
                         currentState.setEvent(e);
                         currentState.setPath(path);
                     }
-                    if (species != null && !species.equals(currentState.getSpecies())) {
+                    if (species != null && !species.equals(currentState.getSpecies()) && currentState.getSpeciesList().contains(species)) {
                         eventBus.fireEventFromSource(new SpeciesSelectedEvent(species), this);
                         return;
                     }

--- a/src/main/java/org/reactome/web/pwp/client/manager/state/StateManager.java
+++ b/src/main/java/org/reactome/web/pwp/client/manager/state/StateManager.java
@@ -38,6 +38,8 @@ public class StateManager implements BrowserModule.Manager, ValueChangeHandler<S
 
     private State currentState;
 
+    private List<Species> speciesList;
+
     public StateManager(EventBus eventBus) {
         this.eventBus = eventBus;
         new TitleManager(eventBus);
@@ -99,8 +101,7 @@ public class StateManager implements BrowserModule.Manager, ValueChangeHandler<S
 
     @Override
     public void onSpeciesListRetrieved(SpeciesListRetrievedEvent event) {
-        State state = new State(this.currentState);
-        state.setSpeciesList(event.getSpeciesList());
+        this.speciesList = event.getSpeciesList();
     }
 
     @Override
@@ -135,7 +136,7 @@ public class StateManager implements BrowserModule.Manager, ValueChangeHandler<S
                         currentState.setEvent(e);
                         currentState.setPath(path);
                     }
-                    if (species != null && !species.equals(currentState.getSpecies()) && currentState.getSpeciesList().contains(species)) {
+                    if (species != null && !species.equals(currentState.getSpecies()) && speciesList.contains(species)) {
                         eventBus.fireEventFromSource(new SpeciesSelectedEvent(species), this);
                         return;
                     }

--- a/src/main/java/org/reactome/web/pwp/client/toppanel/species/SpeciesSelectorPresenter.java
+++ b/src/main/java/org/reactome/web/pwp/client/toppanel/species/SpeciesSelectorPresenter.java
@@ -2,6 +2,7 @@ package org.reactome.web.pwp.client.toppanel.species;
 
 import com.google.gwt.event.shared.EventBus;
 import org.reactome.web.pwp.client.common.events.ErrorMessageEvent;
+import org.reactome.web.pwp.client.common.events.SpeciesListRetrievedEvent;
 import org.reactome.web.pwp.client.common.events.SpeciesSelectedEvent;
 import org.reactome.web.pwp.client.common.events.StateChangedEvent;
 import org.reactome.web.pwp.client.common.module.AbstractPresenter;
@@ -66,6 +67,7 @@ public class SpeciesSelectorPresenter extends AbstractPresenter implements Speci
                 speciesList = list;
                 display.setData(speciesList);
                 loaded = true;
+                eventBus.fireEventFromSource(new SpeciesListRetrievedEvent(speciesList), this);
                 switchDisplayToSpecies(currentSpecies);
             }
 
@@ -83,4 +85,5 @@ public class SpeciesSelectorPresenter extends AbstractPresenter implements Speci
             }
         });
     }
+
 }


### PR DESCRIPTION
fix for [bug](https://trello.com/c/XXwZJVKp/5-browser-gee-and-otherentity-broken-link-when-click-on-the-icon)

The issue in this case is that when reaction components specie(s) is different from the reaction species and the reaction component specie(s) is not a [main specie](https://reactome.org/ContentService/#/species/getSpeciesUsingGET), and the icon for such a component is clicked, we get an error. The error is because the code attempts to reload the pathway browser in the reaction component specie(s) context and fails.

This PR adds a check to handle that case. 