### PR TITLE
added ability to set more URL variables and fixed bug removing FLGINT…

### DIFF
--- a/src/main/java/org/reactome/web/pwp/client/manager/state/State.java
+++ b/src/main/java/org/reactome/web/pwp/client/manager/state/State.java
@@ -51,10 +51,12 @@ public class State {
 
     private String flag;
     private boolean flagIncludeInteractors = false;
+    private Map<String, String> extraParams; //to enable extensions of Reactome project to add extra url parameters
 
     public State(Token token, final StateLoadedHandler handler) {
         List<String> toLoad = token.getToLoad();
         final Map<StateKey, String> parameters = token.getParameters();
+        this.extraParams = token.getExtraParams();
         ContentClient.query(toLoad, new ContentClientHandler.ObjectMapLoaded() {
             private String token;
             private String filter;
@@ -131,6 +133,7 @@ public class State {
         this.analysisStatus = state.analysisStatus;
         this.flag = state.flag;
         this.flagIncludeInteractors = state.flagIncludeInteractors;
+        this.extraParams = state.extraParams;
     }
 
     void doConsistencyCheck(final StateLoadedHandler handler) {
@@ -336,12 +339,19 @@ public class State {
             }
 //            addDelimiter=true;
         }
+        if(extraParams != null) {
+        	extraParams.forEach((k,v) -> {
+        		token.append("&");
+        		token.append(k);
+        		token.append("=");
+        		token.append(v);
+        	});
+        }
         return token.toString();
     }
 
     /**
      * Returns the path until the loaded diagram (without including it)
-     *
      * @return the path until the loaded diagram (without including it)
      */
     private Path getPrunedPath() {

--- a/src/main/java/org/reactome/web/pwp/client/manager/state/StateManager.java
+++ b/src/main/java/org/reactome/web/pwp/client/manager/state/StateManager.java
@@ -165,6 +165,7 @@ public class StateManager implements BrowserModule.Manager, ValueChangeHandler<S
     public void onDiagramObjectsFlagReset(DiagramObjectsFlagResetEvent event) {
         State desiredState = new State(this.currentState);
         desiredState.setFlag(null);
+        desiredState.setFlagIncludeInteractors(false); //want to set this to false regardless to remove it from url on Flag close.
         this.eventBus.fireEventFromSource(new StateChangedEvent(desiredState), this);
     }
 

--- a/src/main/java/org/reactome/web/pwp/client/manager/state/token/Token.java
+++ b/src/main/java/org/reactome/web/pwp/client/manager/state/token/Token.java
@@ -14,14 +14,16 @@ public class Token {
     public static String DELIMITER;        // Default in Reactome is "&" -> to be set in Browser.java
 
     private Map<StateKey, String> parameters;
+    private Map<String, String> extraParamMap;
     private boolean wellFormed = true;
 
     public Token(String token) throws TokenMalformedException {
         if(DEFAULT_SPECIES_ID==null || DELIMITER==null) throw new RuntimeException("Please initialise DEFAULT_SPECIES_ID and DELIMITER");
         if (token.startsWith("/")) token = token.substring(1);
 //        if(token.isEmpty()) token = StateKey.SPECIES.getDefaultKey() + "=" + DEFAULT_SPECIES_ID;
-
+        
         this.parameters = new HashMap<>();
+        this.extraParamMap = new HashMap<>();
         try {
             @SuppressWarnings("NonJREEmulationClassesInClientCode")
             String[] tokens = token.split(DELIMITER);
@@ -38,7 +40,7 @@ public class Token {
                         if (key != null) {
                             parameters.put(key, ts[1]);
                         } else {
-                            wellFormed = false;
+                            extraParamMap.put(ts[0], ts[1]);
                         }
                     }
                 }
@@ -60,6 +62,10 @@ public class Token {
 
     public Map<StateKey, String> getParameters() {
         return this.parameters;
+    }
+    
+    public Map<String, String> getExtraParams() {
+    	return extraParamMap;
     }
 
     public List<String> getToLoad(){


### PR DESCRIPTION
Added map to Token and State to manage extra url arguments. Extra arguments will always be appended to end of url when state is changed until they are removed by setting a new History token using GWT's History.newItem();

Also, I fixed a bug in StateManager.onDiagramObjectFlagReset() where FLGINT was not removed when flag is reset